### PR TITLE
Remove `es6-promisify` and add `promisify-node`

### DIFF
--- a/rplugin/node/tigris.js/package.json
+++ b/rplugin/node/tigris.js/package.json
@@ -5,8 +5,8 @@
   "repository": "https://github.com/billyvg/tigris.nvim",
   "main": "lib/index.js",
   "dependencies": {
-    "es6-promisify": "^4.1.0",
     "lodash": "^4.13.1",
+    "promisify-node": "^0.4.0",
     "regenerator-runtime": "^0.9.5",
     "update-notifier": "^1.0.2",
     "vim-syntax-parser": "^0.1.0"


### PR DESCRIPTION
`es6-promisify` is not used, `promisify-node` is used, but missing dependency.

That's why `:UpdateRemotePlugins` not working #5 .
